### PR TITLE
Fix inputAccessoryView tint color issue

### DIFF
--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -36,7 +36,6 @@
     _prevNext = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:NSLocalizedString(@"Previous", @""), NSLocalizedString(@"Next", @""), nil]];
     _prevNext.momentary = YES;
     _prevNext.segmentedControlStyle = UISegmentedControlStyleBar;
-    _prevNext.tintColor = actionBar.tintColor;
     [_prevNext addTarget:self action:@selector(handleActionBarPreviousNext:) forControlEvents:UIControlEventValueChanged];
     UIBarButtonItem *prevNextWrapper = [[UIBarButtonItem alloc] initWithCustomView:_prevNext];
     UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];


### PR DESCRIPTION
actionBar.tintColor is nil because the action bar is not in the view hierarchy, so this line isn't useful and is actually harmful because it overrides UIAppearance tintColor definitions.
